### PR TITLE
Fix Light Mode Reload Issue

### DIFF
--- a/src/components/HeadSEO.astro
+++ b/src/components/HeadSEO.astro
@@ -73,5 +73,25 @@ const ogImage = new URL("og-image.png", siteUrl).toString();
 
   <ClientRouter />
 
+  <script is:inline>
+    const applyTheme = () => {
+      const theme = (() => {
+        if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
+          return localStorage.getItem('theme');
+        }
+        return 'dark';
+      })();
+      if (theme === 'light') {
+        document.documentElement.classList.remove('dark');
+      } else {
+        document.documentElement.classList.add('dark');
+      }
+    };
+
+    applyTheme();
+
+    document.addEventListener('astro:after-swap', applyTheme);
+  </script>
+
   <Font cssVariable="--font-geist" preload />
 </head>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -20,6 +20,9 @@ export function ThemeToggle() {
     } else {
       document.documentElement.classList.remove("dark");
     }
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem("theme", nextTheme);
+    }
   };
 
   return (


### PR DESCRIPTION
This change adds robust client-side theme persistence for light and dark modes.

- Updates the `ThemeToggle` component to save the next theme value to `localStorage`.
- Inserts an inline `<script>` into the `<head>` of `HeadSEO.astro` to synchronously check `localStorage` (defaulting to dark mode) and apply the `dark` class before rendering.
- Adds an `astro:after-swap` listener to ensure correct theme preservation during client-side transitions.

---
*PR created automatically by Jules for task [5789024566221156588](https://jules.google.com/task/5789024566221156588) started by @torn4dom4n*