### PR TITLE
Corrected site tags and enforced Zod schema validation

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,23 @@
 import { defineCollection, z } from "astro:content";
 import { file } from "astro/loaders";
 
+export const VALID_TAGS = [
+  "ai",
+  "components",
+  "design",
+  "develop",
+  "download",
+  "explore",
+  "language",
+  "learn",
+  "opensource",
+  "photo",
+  "share",
+  "tool",
+  "ui",
+  "video",
+] as const;
+
 const sites = defineCollection({
   loader: file("src/content/sites.json"),
   schema: z.object({
@@ -8,7 +25,7 @@ const sites = defineCollection({
     title: z.string(),
     url: z.string().url(),
     description: z.string(),
-    tags: z.array(z.string()).optional(),
+    tags: z.array(z.enum(VALID_TAGS)).optional(),
   }),
 });
 

--- a/src/content/sites.json
+++ b/src/content/sites.json
@@ -361,7 +361,7 @@
     "title": "Lucidchart",
     "url": "https://lucid.app",
     "description": "Diagramming powered by intelligence.",
-    "tags": ["tools", "ai"]
+    "tags": ["tool", "ai"]
   },
   {
     "id": "ludwig",
@@ -543,7 +543,7 @@
     "title": "Sentence dictionary design",
     "url": "https://sentencedict.com",
     "description": "Good sentence examples for every word.",
-    "tags": ["english", "tool"]
+    "tags": ["language", "tool"]
   },
   {
     "id": "sentence-stack",
@@ -557,7 +557,7 @@
     "title": "Serial & keys",
     "url": "https://www.serials.ws",
     "description": "Serials & keys - unlocks the world.",
-    "tags": ["hack"]
+    "tags": ["download"]
   },
   {
     "id": "shadcn-ui",
@@ -578,7 +578,7 @@
     "title": "Slidesgo",
     "url": "https://slidesgo.com",
     "description": "Free Google Slides and PowerPoint templates.",
-    "tags": ["download", "ms-office"]
+    "tags": ["download", "design"]
   },
   {
     "id": "smallpdf",


### PR DESCRIPTION
I have corrected all single-use and inconsistent tags across the bookmark database and implemented strict build-time validation in the Astro content collection configuration using Zod enum schemas.

---
*PR created automatically by Jules for task [14866957023555949963](https://jules.google.com/task/14866957023555949963) started by @torn4dom4n*