### PR TITLE
Add J2TEAM Free Tools and Recent.Design to sites catalog

### DIFF
--- a/src/content/sites.json
+++ b/src/content/sites.json
@@ -350,6 +350,13 @@
     "tags": ["design", "video", "tool"]
   },
   {
+    "id": "j2team-free",
+    "title": "J2TEAM Free Tools",
+    "url": "https://j2team.org/free",
+    "description": "A collection of powerful free tools for developers, designers, and everyday users with no registration required.",
+    "tags": ["design", "develop", "tool"]
+  },
+  {
     "id": "jitter",
     "title": "Jitter",
     "url": "https://jitter.video",
@@ -572,6 +579,13 @@
     "url": "https://readable.com",
     "description": "Readable will quickly test the readability, spelling and grammar of your text and show you how and where to make improvements.",
     "tags": ["language", "tool"]
+  },
+  {
+    "id": "recent-design",
+    "title": "Recent.Design",
+    "url": "https://recent.design/",
+    "description": "A curated platform showcasing the latest trends in web, interface, and interaction design for design inspiration.",
+    "tags": ["design", "explore", "ui"]
   },
   {
     "id": "reduced-to",


### PR DESCRIPTION
Added the following websites to the `sites.json` content collection:
- `https://j2team.org/free` (J2TEAM Free Tools) with tags `design`, `develop`, `tool`
- `https://recent.design/` (Recent.Design) with tags `design`, `explore`, `ui`

Verified alphabetical ordering by ID and ran Biome checks as well as Astro builds to confirm correctness. Visual verification was also conducted using Playwright screenshots.

---
*PR created automatically by Jules for task [13111139544697785295](https://jules.google.com/task/13111139544697785295) started by @torn4dom4n*