### PR TITLE
Add dead link checker and enable GitHub CI integration

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
 
       - name: Install dependencies
@@ -44,7 +44,7 @@ jobs:
 
       - name: Create Pull Request for Dead Links Clean-up
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: automatically remove dead links from sites.json"

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,16 +1,17 @@
-name: Dead Link Checker
+name: Link Checker
 
 on:
   push:
     branches: ["main"]
   pull_request:
   schedule:
-    # Run daily at midnight UTC
-    - cron: "0 0 * * *"
+    # Run weekly on Sunday at midnight UTC
+    - cron: "0 0 * * 0"
   workflow_dispatch: # Allows manual run
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   link-checker:
@@ -33,5 +34,29 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run link checker
+      - name: Run link checker (validate only)
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
         run: pnpm run check-links
+
+      - name: Run link checker and fix dead links
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: pnpm run check-links --write
+
+      - name: Create Pull Request for Dead Links Clean-up
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: automatically remove dead links from sites.json"
+          committer: GitHub <noreply@github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          signoff: false
+          branch: chore/remove-dead-links
+          delete-branch: true
+          title: "chore: automatically remove dead links from sites.json"
+          body: |
+            This PR was automatically created by the weekly Link Checker workflow.
+            It filters out dead links detected during the validation process.
+          labels: |
+            chore
+            automated-pr

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,37 @@
+name: Dead Link Checker
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  schedule:
+    # Run daily at midnight UTC
+    - cron: "0 0 * * *"
+  workflow_dispatch: # Allows manual run
+
+permissions:
+  contents: read
+
+jobs:
+  link-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run link checker
+        run: pnpm run check-links

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "biome format --write",
     "lint": "biome lint --write",
     "check": "biome check --write",
-    "check-links": "node scripts/check-links.mjs"
+    "check-links": "node --experimental-strip-types scripts/check-links.mts"
   },
   "dependencies": {
     "@astrojs/react": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "biome format --write",
     "lint": "biome lint --write",
     "check": "biome check --write",
-    "check-links": "node --experimental-strip-types scripts/check-links.mts"
+    "check-links": "node scripts/check-links.mjs"
   },
   "dependencies": {
     "@astrojs/react": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "preview": "astro preview",
     "format": "biome format --write",
     "lint": "biome lint --write",
-    "check": "biome check --write"
+    "check": "biome check --write",
+    "check-links": "node --experimental-strip-types scripts/check-links.mts"
   },
   "dependencies": {
     "@astrojs/react": "^6.0.2",

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const USER_AGENT =
@@ -7,37 +7,9 @@ const TIMEOUT_MS = 10000; // 10 seconds
 const CONCURRENCY = 10;
 const RETRY_DELAY_MS = 1500;
 
-interface Site {
-  id: string;
-  title: string;
-  url: string;
-  description: string;
-  tags: string[];
-}
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-type LinkStatus = "ALIVE" | "DEAD" | "UNREACHABLE";
-
-interface CheckResult {
-  site: Site;
-  status: LinkStatus;
-  httpStatus?: number;
-  error?: string;
-  methodUsed: "HEAD" | "GET";
-  retries: number;
-}
-
-// Helper to wait
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-async function fetchWithTimeout(
-  url: string,
-  method: "HEAD" | "GET"
-): Promise<{
-  success: boolean;
-  status?: number;
-  error?: string;
-  isDnsError?: boolean;
-}> {
+async function fetchWithTimeout(url, method) {
   try {
     const response = await fetch(url, {
       method,
@@ -58,7 +30,7 @@ async function fetchWithTimeout(
       status: response.status,
       error: `Status ${response.status} (${response.statusText})`,
     };
-  } catch (error: unknown) {
+  } catch (error) {
     let errorMsg = "Unknown error";
     let isDnsError = false;
 
@@ -70,9 +42,7 @@ async function fetchWithTimeout(
       }
 
       // Check Node's native fetch (undici) DNS errors safely
-      const cause = error.cause as
-        | { code?: string; errno?: string }
-        | undefined;
+      const cause = error.cause;
       const causeCode = cause?.code || cause?.errno;
       if (causeCode === "ENOTFOUND" || error.message.includes("ENOTFOUND")) {
         isDnsError = true;
@@ -89,20 +59,14 @@ async function fetchWithTimeout(
   }
 }
 
-async function checkLink(site: Site): Promise<CheckResult> {
+async function checkLink(site) {
   const url = site.url;
   let retries = 0;
 
-  const attemptCheck = async (): Promise<{
-    success: boolean;
-    httpStatus?: number;
-    error?: string;
-    isDnsError?: boolean;
-    methodUsed: "HEAD" | "GET";
-  }> => {
+  const attemptCheck = async () => {
     // 1. Try HEAD first
     let res = await fetchWithTimeout(url, "HEAD");
-    let methodUsed: "HEAD" | "GET" = "HEAD";
+    let methodUsed = "HEAD";
 
     // 2. Fallback to GET if HEAD failed
     if (!res.success) {
@@ -134,7 +98,7 @@ async function checkLink(site: Site): Promise<CheckResult> {
   }
 
   // Categorize result
-  let status: LinkStatus = "ALIVE";
+  let status = "ALIVE";
   if (!check.success) {
     if (
       check.httpStatus === 404 ||
@@ -160,12 +124,12 @@ async function checkLink(site: Site): Promise<CheckResult> {
 async function main() {
   console.log("Starting dead link check...");
   const sitesPath = join(process.cwd(), "src/content/sites.json");
-  let sites: Site[] = [];
+  let sites = [];
 
   try {
     const rawData = readFileSync(sitesPath, "utf-8");
     sites = JSON.parse(rawData);
-  } catch (err: unknown) {
+  } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
     console.error("Failed to read/parse sites.json:", errorMessage);
     process.exit(1);
@@ -173,7 +137,7 @@ async function main() {
 
   console.log(`Found ${sites.length} sites to check.`);
 
-  const results: CheckResult[] = [];
+  const results = [];
   let activeIndex = 0;
 
   async function worker() {
@@ -203,7 +167,7 @@ async function main() {
     }
   }
 
-  const workers: Promise<void>[] = [];
+  const workers = [];
   const limit = Math.min(CONCURRENCY, sites.length);
   for (let i = 0; i < limit; i++) {
     workers.push(worker());
@@ -223,20 +187,45 @@ async function main() {
   console.log(`Dead (Critical): ${dead.length}`);
   console.log("====================================\n");
 
+  const shouldWrite = process.argv.includes("--write");
+
   if (dead.length > 0) {
     console.error("Critical: The following DEAD links were detected:");
     for (const item of dead) {
       console.error(`- [${item.site.id}] ${item.site.title}: ${item.site.url}`);
       console.error(`  Reason: ${item.error}`);
     }
-    process.exit(1);
+
+    if (shouldWrite) {
+      console.log(
+        "\nWriting back to sites.json with DEAD links filtered out..."
+      );
+      const deadIds = new Set(dead.map((d) => d.site.id));
+      const filteredSites = sites.filter((s) => !deadIds.has(s.id));
+      try {
+        writeFileSync(
+          sitesPath,
+          `${JSON.stringify(filteredSites, null, 2)}\n`,
+          "utf-8"
+        );
+        console.log(
+          `Filtered sites written successfully. (Removed ${dead.length} dead links).`
+        );
+        process.exit(0); // exit 0 because they are handled
+      } catch (writeErr) {
+        console.error("Failed to write updated sites.json:", writeErr.message);
+        process.exit(1);
+      }
+    } else {
+      process.exit(1);
+    }
   } else {
     console.log("All links are active, healthy, or safely unreachable! 🎉");
     process.exit(0);
   }
 }
 
-main().catch((err: unknown) => {
+main().catch((err) => {
   console.error("An unexpected error occurred during link check:", err);
   process.exit(1);
 });

--- a/scripts/check-links.mts
+++ b/scripts/check-links.mts
@@ -7,9 +7,36 @@ const TIMEOUT_MS = 10000; // 10 seconds
 const CONCURRENCY = 10;
 const RETRY_DELAY_MS = 1500;
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+interface Site {
+  id: string;
+  title: string;
+  url: string;
+  description: string;
+  tags: string[];
+}
 
-async function fetchWithTimeout(url, method) {
+type LinkStatus = "ALIVE" | "DEAD" | "UNREACHABLE";
+
+interface CheckResult {
+  site: Site;
+  status: LinkStatus;
+  httpStatus?: number;
+  error?: string;
+  methodUsed: "HEAD" | "GET";
+  retries: number;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function fetchWithTimeout(
+  url: string,
+  method: "HEAD" | "GET"
+): Promise<{
+  success: boolean;
+  status?: number;
+  error?: string;
+  isDnsError?: boolean;
+}> {
   try {
     const response = await fetch(url, {
       method,
@@ -30,7 +57,7 @@ async function fetchWithTimeout(url, method) {
       status: response.status,
       error: `Status ${response.status} (${response.statusText})`,
     };
-  } catch (error) {
+  } catch (error: unknown) {
     let errorMsg = "Unknown error";
     let isDnsError = false;
 
@@ -42,7 +69,9 @@ async function fetchWithTimeout(url, method) {
       }
 
       // Check Node's native fetch (undici) DNS errors safely
-      const cause = error.cause;
+      const cause = error.cause as
+        | { code?: string; errno?: string }
+        | undefined;
       const causeCode = cause?.code || cause?.errno;
       if (causeCode === "ENOTFOUND" || error.message.includes("ENOTFOUND")) {
         isDnsError = true;
@@ -59,14 +88,20 @@ async function fetchWithTimeout(url, method) {
   }
 }
 
-async function checkLink(site) {
+async function checkLink(site: Site): Promise<CheckResult> {
   const url = site.url;
   let retries = 0;
 
-  const attemptCheck = async () => {
+  const attemptCheck = async (): Promise<{
+    success: boolean;
+    httpStatus?: number;
+    error?: string;
+    isDnsError?: boolean;
+    methodUsed: "HEAD" | "GET";
+  }> => {
     // 1. Try HEAD first
     let res = await fetchWithTimeout(url, "HEAD");
-    let methodUsed = "HEAD";
+    let methodUsed: "HEAD" | "GET" = "HEAD";
 
     // 2. Fallback to GET if HEAD failed
     if (!res.success) {
@@ -98,7 +133,7 @@ async function checkLink(site) {
   }
 
   // Categorize result
-  let status = "ALIVE";
+  let status: LinkStatus = "ALIVE";
   if (!check.success) {
     if (
       check.httpStatus === 404 ||
@@ -124,12 +159,12 @@ async function checkLink(site) {
 async function main() {
   console.log("Starting dead link check...");
   const sitesPath = join(process.cwd(), "src/content/sites.json");
-  let sites = [];
+  let sites: Site[] = [];
 
   try {
     const rawData = readFileSync(sitesPath, "utf-8");
     sites = JSON.parse(rawData);
-  } catch (err) {
+  } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
     console.error("Failed to read/parse sites.json:", errorMessage);
     process.exit(1);
@@ -137,7 +172,7 @@ async function main() {
 
   console.log(`Found ${sites.length} sites to check.`);
 
-  const results = [];
+  const results: CheckResult[] = [];
   let activeIndex = 0;
 
   async function worker() {
@@ -167,7 +202,7 @@ async function main() {
     }
   }
 
-  const workers = [];
+  const workers: Promise<void>[] = [];
   const limit = Math.min(CONCURRENCY, sites.length);
   for (let i = 0; i < limit; i++) {
     workers.push(worker());
@@ -211,9 +246,11 @@ async function main() {
         console.log(
           `Filtered sites written successfully. (Removed ${dead.length} dead links).`
         );
-        process.exit(0); // exit 0 because they are handled
-      } catch (writeErr) {
-        console.error("Failed to write updated sites.json:", writeErr.message);
+        process.exit(0);
+      } catch (writeErr: unknown) {
+        const writeErrMessage =
+          writeErr instanceof Error ? writeErr.message : String(writeErr);
+        console.error("Failed to write updated sites.json:", writeErrMessage);
         process.exit(1);
       }
     } else {
@@ -225,7 +262,7 @@ async function main() {
   }
 }
 
-main().catch((err) => {
+main().catch((err: unknown) => {
   console.error("An unexpected error occurred during link check:", err);
   process.exit(1);
 });

--- a/scripts/check-links.mts
+++ b/scripts/check-links.mts
@@ -74,14 +74,14 @@ async function fetchWithTimeout(
         | { code?: string; errno?: string }
         | undefined;
       const causeCode = cause?.code || cause?.errno;
-      if (
-        causeCode === "ENOTFOUND" ||
-        causeCode === "EAI_AGAIN" ||
-        error.message.includes("ENOTFOUND") ||
-        error.message.includes("EAI_AGAIN")
-      ) {
+      if (causeCode === "ENOTFOUND" || error.message.includes("ENOTFOUND")) {
         isDnsError = true;
         errorMsg = `DNS lookup failed (${causeCode || "ENOTFOUND"})`;
+      } else if (
+        causeCode === "EAI_AGAIN" ||
+        error.message.includes("EAI_AGAIN")
+      ) {
+        errorMsg = `Temporary DNS lookup failed (${causeCode || "EAI_AGAIN"})`;
       }
     }
 

--- a/scripts/check-links.mts
+++ b/scripts/check-links.mts
@@ -1,0 +1,242 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const TIMEOUT_MS = 10000; // 10 seconds
+const CONCURRENCY = 10;
+const RETRY_DELAY_MS = 1500;
+
+interface Site {
+  id: string;
+  title: string;
+  url: string;
+  description: string;
+  tags: string[];
+}
+
+type LinkStatus = "ALIVE" | "DEAD" | "UNREACHABLE";
+
+interface CheckResult {
+  site: Site;
+  status: LinkStatus;
+  httpStatus?: number;
+  error?: string;
+  methodUsed: "HEAD" | "GET";
+  retries: number;
+}
+
+// Helper to wait
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function fetchWithTimeout(
+  url: string,
+  method: "HEAD" | "GET"
+): Promise<{
+  success: boolean;
+  status?: number;
+  error?: string;
+  isDnsError?: boolean;
+}> {
+  try {
+    const response = await fetch(url, {
+      method,
+      headers: {
+        "User-Agent": USER_AGENT,
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+      },
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      redirect: "follow",
+    });
+
+    if (response.ok) {
+      return { success: true, status: response.status };
+    }
+    return {
+      success: false,
+      status: response.status,
+      error: `Status ${response.status} (${response.statusText})`,
+    };
+  } catch (error: unknown) {
+    let errorMsg = "Unknown error";
+    let isDnsError = false;
+
+    if (error instanceof Error) {
+      if (error.name === "TimeoutError" || error.message.includes("timeout")) {
+        errorMsg = "Timeout after 10s";
+      } else {
+        errorMsg = error.message;
+      }
+
+      // Check Node's native fetch (undici) DNS errors safely
+      const cause = error.cause as
+        | { code?: string; errno?: string }
+        | undefined;
+      const causeCode = cause?.code || cause?.errno;
+      if (
+        causeCode === "ENOTFOUND" ||
+        causeCode === "EAI_AGAIN" ||
+        error.message.includes("ENOTFOUND") ||
+        error.message.includes("EAI_AGAIN")
+      ) {
+        isDnsError = true;
+        errorMsg = `DNS lookup failed (${causeCode || "ENOTFOUND"})`;
+      }
+    }
+
+    return { success: false, error: errorMsg, isDnsError };
+  }
+}
+
+async function checkLink(site: Site): Promise<CheckResult> {
+  const url = site.url;
+  let retries = 0;
+
+  const attemptCheck = async (): Promise<{
+    success: boolean;
+    httpStatus?: number;
+    error?: string;
+    isDnsError?: boolean;
+    methodUsed: "HEAD" | "GET";
+  }> => {
+    // 1. Try HEAD first
+    let res = await fetchWithTimeout(url, "HEAD");
+    let methodUsed: "HEAD" | "GET" = "HEAD";
+
+    // 2. Fallback to GET if HEAD failed
+    if (!res.success) {
+      res = await fetchWithTimeout(url, "GET");
+      methodUsed = "GET";
+    }
+
+    return {
+      success: res.success,
+      httpStatus: res.status,
+      error: res.error,
+      isDnsError: res.isDnsError,
+      methodUsed,
+    };
+  };
+
+  let check = await attemptCheck();
+
+  // If it fails, retry once (only for network/dns failures or non-soft blocks)
+  const isSoftBlock =
+    check.httpStatus === 401 ||
+    check.httpStatus === 403 ||
+    check.httpStatus === 429;
+
+  if (!check.success && !isSoftBlock) {
+    retries++;
+    await sleep(RETRY_DELAY_MS);
+    check = await attemptCheck();
+  }
+
+  // Categorize result
+  let status: LinkStatus = "ALIVE";
+  if (!check.success) {
+    if (
+      check.httpStatus === 404 ||
+      check.httpStatus === 410 ||
+      check.isDnsError
+    ) {
+      status = "DEAD";
+    } else {
+      status = "UNREACHABLE";
+    }
+  }
+
+  return {
+    site,
+    status,
+    httpStatus: check.httpStatus,
+    error: check.error,
+    methodUsed: check.methodUsed,
+    retries,
+  };
+}
+
+async function main() {
+  console.log("Starting dead link check...");
+  const sitesPath = join(process.cwd(), "src/content/sites.json");
+  let sites: Site[] = [];
+
+  try {
+    const rawData = readFileSync(sitesPath, "utf-8");
+    sites = JSON.parse(rawData);
+  } catch (err: unknown) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error("Failed to read/parse sites.json:", errorMessage);
+    process.exit(1);
+  }
+
+  console.log(`Found ${sites.length} sites to check.`);
+
+  const results: CheckResult[] = [];
+  let activeIndex = 0;
+
+  async function worker() {
+    while (activeIndex < sites.length) {
+      const currentIndex = activeIndex++;
+      const site = sites[currentIndex];
+
+      const progress = `[${currentIndex + 1}/${sites.length}]`;
+      const result = await checkLink(site);
+      results[currentIndex] = result;
+
+      const retryText = result.retries > 0 ? " (after retry)" : "";
+
+      if (result.status === "ALIVE") {
+        console.log(
+          `${progress} ✅ ${site.title} (${site.url}) - Success (${result.methodUsed})${retryText}`
+        );
+      } else if (result.status === "UNREACHABLE") {
+        console.warn(
+          `${progress} ⚠️  ${site.title} (${site.url}) - Unreachable/Blocked (${result.methodUsed})${retryText}: ${result.error}`
+        );
+      } else {
+        console.error(
+          `${progress} ❌ ${site.title} (${site.url}) - DEAD (${result.methodUsed})${retryText}: ${result.error}`
+        );
+      }
+    }
+  }
+
+  const workers: Promise<void>[] = [];
+  const limit = Math.min(CONCURRENCY, sites.length);
+  for (let i = 0; i < limit; i++) {
+    workers.push(worker());
+  }
+
+  await Promise.all(workers);
+
+  const dead = results.filter((r) => r.status === "DEAD");
+  const unreachable = results.filter((r) => r.status === "UNREACHABLE");
+  const alive = results.filter((r) => r.status === "ALIVE");
+
+  console.log("\n====================================");
+  console.log("Link Check Summary:");
+  console.log(`Total sites checked: ${sites.length}`);
+  console.log(`Active (Alive): ${alive.length}`);
+  console.log(`Unreachable/Soft-fail: ${unreachable.length}`);
+  console.log(`Dead (Critical): ${dead.length}`);
+  console.log("====================================\n");
+
+  if (dead.length > 0) {
+    console.error("Critical: The following DEAD links were detected:");
+    for (const item of dead) {
+      console.error(`- [${item.site.id}] ${item.site.title}: ${item.site.url}`);
+      console.error(`  Reason: ${item.error}`);
+    }
+    process.exit(1);
+  } else {
+    console.log("All links are active, healthy, or safely unreachable! 🎉");
+    process.exit(0);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error("An unexpected error occurred during link check:", err);
+  process.exit(1);
+});

--- a/src/content/sites.json
+++ b/src/content/sites.json
@@ -38,7 +38,7 @@
     "id": "alison",
     "title": "Alison",
     "url": "https://alison.com",
-    "description": "Free design Courses from the World\u2019s Top Publishers.",
+    "description": "Free design Courses from the World’s Top Publishers.",
     "tags": ["learn"]
   },
   {
@@ -129,7 +129,7 @@
     "id": "chatgpt",
     "title": "ChatGPT",
     "url": "https://chatgpt.com",
-    "description": "ChatGPT is a sibling model to InstructGPT\u2060, which is trained to follow an instruction in a prompt and provide a detailed response.",
+    "description": "ChatGPT is a sibling model to InstructGPT⁠, which is trained to follow an instruction in a prompt and provide a detailed response.",
     "tags": ["ai", "tool"]
   },
   {
@@ -332,15 +332,8 @@
     "id": "imgur",
     "title": "Imgur",
     "url": "https://imgur.com",
-    "description": "Where you\u2019ll find the funniest, most informative and inspiring images, memes, GIFs, and visual stories served up in an endless stream of bite-sized fun.",
+    "description": "Where you’ll find the funniest, most informative and inspiring images, memes, GIFs, and visual stories served up in an endless stream of bite-sized fun.",
     "tags": ["explore", "photo"]
-  },
-  {
-    "id": "inpainting",
-    "title": "Inpainting",
-    "url": "https://inpainter.vercel.app",
-    "description": "Inpainting is a process where missing parts of an artwork are filled in to present a complete image.",
-    "tags": ["ai", "photo", "tool"]
   },
   {
     "id": "introcave",
@@ -427,13 +420,6 @@
     "tags": ["develop", "opensource", "tool"]
   },
   {
-    "id": "next-ai-chatbot",
-    "title": "Next.js AI Chatbot",
-    "url": "https://chat.vercel.ai/",
-    "description": "This is an open source AI chatbot app template built with Next.js, the Vercel AI SDK, and Vercel KV.",
-    "tags": ["ai", "tool"]
-  },
-  {
     "id": "novel",
     "title": "Novel",
     "url": "https://novel.sh",
@@ -469,17 +455,10 @@
     "tags": ["opensource", "develop"]
   },
   {
-    "id": "orginkit",
-    "title": "OrginKit",
-    "url": "https://orginkit.dev",
-    "description": "A collection of modular, production-ready Tailwind CSS and React components and UI kits.",
-    "tags": ["design", "develop", "ui"]
-  },
-  {
     "id": "padlet",
     "title": "Padlet",
     "url": "https://padlet.com",
-    "description": "It\u2019s a starry night. Make something stellar.",
+    "description": "It’s a starry night. Make something stellar.",
     "tags": ["share"]
   },
   {
@@ -502,13 +481,6 @@
     "url": "https://pagespeed.web.dev",
     "description": "PageSpeed Insights (PSI) reports on the user experience of a page on both mobile and desktop devices, and provides suggestions on how that page may be improved.",
     "tags": ["develop", "tool"]
-  },
-  {
-    "id": "paint-by-text",
-    "title": "Paint by Text",
-    "url": "https://paintbytext.chat",
-    "description": "Edit your photos using written instructions, with the help of an AI.",
-    "tags": ["ai", "photo", "tool"]
   },
   {
     "id": "pdf-archive",
@@ -588,13 +560,6 @@
     "tags": ["design", "explore", "ui"]
   },
   {
-    "id": "reduced-to",
-    "title": "Reduced.to",
-    "url": "https://reduced.to",
-    "description": "Add your very long URL in the input below and click on the button to make it shorter.",
-    "tags": ["tool"]
-  },
-  {
     "id": "reicon",
     "title": "Reicon",
     "url": "https://reicon.dev/",
@@ -623,17 +588,10 @@
     "tags": ["ai", "photo", "tool"]
   },
   {
-    "id": "reviet-design",
-    "title": "Reviet Design",
-    "url": "https://reviet.design",
-    "description": "A curated library of premium design resources, UI/UX templates, and assets for designers and developers.",
-    "tags": ["design", "explore", "ui"]
-  },
-  {
     "id": "rgadguard",
-    "title": "List of files by Microsoft\u00ae",
+    "title": "List of files by Microsoft®",
     "url": "https://files.rg-adguard.net",
-    "description": "List of files by Microsoft\u00ae.",
+    "description": "List of files by Microsoft®.",
     "tags": ["download"]
   },
   {
@@ -655,13 +613,6 @@
     "title": "Sentence dictionary design",
     "url": "https://sentencedict.com",
     "description": "Good sentence examples for every word.",
-    "tags": ["language", "tool"]
-  },
-  {
-    "id": "sentence-stack",
-    "title": "Sentence Stack",
-    "url": "https://sentencestack.com",
-    "description": "Improve your English with our linguistic search engine backed by 300+ million sentences.",
     "tags": ["language", "tool"]
   },
   {
@@ -794,15 +745,8 @@
     "id": "vecel-og-playground",
     "title": "Vercel OG Image Playground",
     "url": "https://og-playground.vercel.app",
-    "description": "Generate Open Graph images with Vercel\u2019s Edge Function.",
+    "description": "Generate Open Graph images with Vercel’s Edge Function.",
     "tags": ["develop", "tool", "opensource"]
-  },
-  {
-    "id": "vscheatsheet",
-    "title": "VSCheatsheet",
-    "url": "https://www.vscheatsheet.com",
-    "description": "Shortcuts in the shortest time possible.",
-    "tags": ["tool"]
   },
   {
     "id": "windstatic",
@@ -831,20 +775,6 @@
     "url": "https://images.weserv.nl",
     "description": "An image cache & resize service.",
     "tags": ["photo", "develop", "tool"]
-  },
-  {
-    "id": "y2mate",
-    "title": "Y2mate",
-    "url": "https://www.y2mate.com",
-    "description": "Download Video and Audio from YouTube.",
-    "tags": ["download", "tool"]
-  },
-  {
-    "id": "yify-movies",
-    "title": "YIFY movies",
-    "url": "https://yts.mx",
-    "description": "Movies Torrent Download.",
-    "tags": ["download", "tool"]
   },
   {
     "id": "yopmail",


### PR DESCRIPTION
This adds a robust, concurrent, retry-enabled dead link checker script (`scripts/check-links.mts`) to inspect links within `src/content/sites.json`. The checker distinguishes critical dead links (404, 410, DNS lookup failure) from soft failures (401, 403, 429, timeouts, 5xx) to guarantee that actual dead links are detected while keeping CI execution completely non-flaky and robust. A GitHub Actions workflow (`.github/workflows/link-checker.yml`) is set up to automatically execute on push, pull requests, and daily cron schedule.

---
*PR created automatically by Jules for task [12586973147349206420](https://jules.google.com/task/12586973147349206420) started by @torn4dom4n*